### PR TITLE
Add BentoBox compatibility.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("world.bentobox:bentobox:2.0.0-SNAPSHOT")
+    compileOnly("world.bentobox:bentobox:2.0.0-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT")
     compileOnly("com.palmergames.bukkit.towny:towny:0.100.1.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
     maven("https://maven.enginehub.org/repo/")
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://jitpack.io")
+    maven{"https://repo.codemc.org/repository/maven-public/"}
 }
 
 dependencies {
@@ -37,6 +38,7 @@ dependencies {
     compileOnly("com.plotsquared:PlotSquared-Core")
     compileOnly("com.plotsquared:PlotSquared-Bukkit")
     compileOnly("com.github.TechFortress:GriefPrevention:16.18")
+    compileOnly("world.bentobox:bentobox:1.24.1")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,16 +13,18 @@ version = pluginVersion
 repositories {
     mavenCentral()
     //mavenLocal()
+    maven("https://repo.codemc.org/repository/maven-public/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://ci.ender.zone/plugin/repository/everything/")
     maven("https://repo.glaremasters.me/repository/towny/")
     maven("https://maven.enginehub.org/repo/")
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://jitpack.io")
-    maven{"https://repo.codemc.org/repository/maven-public/"}
+    
 }
 
 dependencies {
+    implementation("world.bentobox:bentobox:2.0.0-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.1.0-SNAPSHOT")
     compileOnly("com.palmergames.bukkit.towny:towny:0.99.2.0")
@@ -38,7 +40,7 @@ dependencies {
     compileOnly("com.plotsquared:PlotSquared-Core")
     compileOnly("com.plotsquared:PlotSquared-Bukkit")
     compileOnly("com.github.TechFortress:GriefPrevention:16.18")
-    compileOnly("world.bentobox:bentobox:1.24.1")
+    
 }
 
 java {

--- a/src/main/java/io/th0rgal/protectionlib/ProtectionLib.java
+++ b/src/main/java/io/th0rgal/protectionlib/ProtectionLib.java
@@ -24,6 +24,7 @@ public class ProtectionLib {
         handleCompatibility("CrashClaim", plugin, (m, p) -> new CrashClaimCompat(m, p));
         handleCompatibility("GriefPrevention", plugin, (m, p) -> new GriefPreventionCompat(m, p));
         handleCompatibility("HuskClaims", plugin, (m, p) -> new HuskClaimCompat(m, p));
+        handleCompatibility("BentoBox", plugin, (m, p) -> new BentoBoxCompat(m, p));
     }
 
     public static boolean canBuild(Player player, Location target) {

--- a/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
+++ b/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
@@ -5,12 +5,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import io.th0rgal.protectionlib.ProtectionCompatibility;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.lists.Flags;
 
-public class BentoBoxCompat {
+public class BentoBoxCompat extends ProtectionCompatibility {
 
     BentoBox plugin = BentoBox.getInstance();
 

--- a/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
+++ b/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
@@ -1,0 +1,70 @@
+package io.th0rgal.protectionlib.compatibilities;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.flags.Flag;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.lists.Flags;
+
+public class BentoBoxCompat {
+
+    BentoBox plugin = BentoBox.getInstance();
+
+    public BentoBoxCompat(JavaPlugin mainPlugin, Plugin plugin) {
+        super(mainPlugin, plugin);
+    }
+
+    /**
+     * @param player Player looking to place a block
+     * @param target Place where the player seeks to place a block
+     * @return true if he can put the block
+     */
+    @Override
+    public boolean canBuild(Player player, Location target) {
+        return canDo(player, target, Flags.PLACE_BLOCKS);
+    }
+
+    private boolean canDo(Player player, Location target, Flag flag) {
+        // Check if in world
+        if (!plugin.getIWM().inWorld(target)) {
+            return true;
+        }
+        return plugin.getIslands().getIslandAt(target).map(island -> island.isAllowed(User.getInstance(player), flag)).orElse(!flag.isSetForWorld(target.getWorld()));
+
+    }
+
+    /**
+     * @param player Player looking to break a block
+     * @param target Place where the player seeks to break a block
+     * @return true if he can break the block
+     */
+    @Override
+    public boolean canBreak(Player player, Location target) {
+        return canDo(player, target, Flags.BREAK_BLOCKS);
+    }
+
+    /**
+     * @param player Player looking to interact with a block
+     * @param target Place where the player seeks to interact with a block
+     * @return true if he can interact with the block
+     */
+    @Override
+    public boolean canInteract(Player player, Location target) {
+        // No single interact flag, so just check if player is on their own island
+        return plugin.getIslands().locationIsOnIsland(player, target);
+    }
+
+    /**
+     * @param player Player looking to use an item
+     * @param target Place where the player seeks to use an item at a location
+     * @return true if he can use the item at the location
+     */
+    public boolean canUse(Player player, Location target) {
+        // No single use flag, so just check if player is on their own island
+        return plugin.getIslands().locationIsOnIsland(player, target);
+    }
+}


### PR DESCRIPTION
This adds support for BentoBox (https://bentobox.world). An admin wanted Oraxen items to be protected on the islands.

It would also be useful if Oraxen could fire Bukkit events, like PlaceBlockEvent because that's what the BentoBox protection natively triggers off, but that's not in this PR.

I could not get my IDE to build using the Gradle setup as-is and I'm a Maven guy, bot Gradle so after two days I gave up and just wrote the code as-is. I think it should work, but it's not tested. If you see an issue, please let me know and I'll try and fix it. FWIW, I'm using Eclipse...

Thanks!