### PR TITLE
Check if player in BentoBox world before restricting use/interact

### DIFF
--- a/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
+++ b/src/main/java/io/th0rgal/protectionlib/compatibilities/BentoBoxCompat.java
@@ -55,6 +55,10 @@ public class BentoBoxCompat extends ProtectionCompatibility {
      */
     @Override
     public boolean canInteract(Player player, Location target) {
+        // Check if in world
+        if (!plugin.getIWM().inWorld(target)) {
+            return true;
+        }
         // No single interact flag, so just check if player is on their own island
         return plugin.getIslands().locationIsOnIsland(player, target);
     }
@@ -65,6 +69,10 @@ public class BentoBoxCompat extends ProtectionCompatibility {
      * @return true if he can use the item at the location
      */
     public boolean canUse(Player player, Location target) {
+        // Check if in world
+        if (!plugin.getIWM().inWorld(target)) {
+            return true;
+        }
         // No single use flag, so just check if player is on their own island
         return plugin.getIslands().locationIsOnIsland(player, target);
     }


### PR DESCRIPTION
Currently not checking if player is in a BentoBox world before restricing use or interact events, adding the same check used for break/place to see if player in a BB world